### PR TITLE
Adding watchify args to the options

### DIFF
--- a/app/templates/gulp/scripts.js
+++ b/app/templates/gulp/scripts.js
@@ -16,12 +16,18 @@ var browserSync = require('browser-sync');
 
 var browserifyTask = function(devMode) {
     var isProduction = (typeof argv.production !== 'undefined') ? true : false;
-    var bundle = browserify({
+    var opts = {
         debug: isProduction ? false : true,
         extensions: ['.js', '.jsx'],
         entries: config.src.js + '/main.js',
         transform: 'babelify'
-    });
+    };
+    
+    if(devMode) {
+      opts = assign({}, watchify.args, opts);
+    }
+    
+    var bundle = browserify(opts);
     if(devMode) {
         bundle = watchify(bundle);
         bundle.on('update', function(){


### PR DESCRIPTION
Adding the `watchify` arguments to the `browserify` options lets `browserify` know that you have a build artifact cache. This reduces build times tremendously. 

Tests with current setup:

No watchify args: ~500-600ms
With watchify args: 70ms

Pinging @thomaspink and @onefriendaday 